### PR TITLE
Remove camera.position.z

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
 			"use strict";
 			var camera, controls, scene, renderer;
 			var theFunctionValue;
-			var size=28;
+			var size=280;
 			var graphArray=[];
 
 			init();
@@ -361,7 +361,7 @@
 				var axes=new THREE.Geometry();
 				axes.verticesNeedUpdate=true;
 
-				for(var i=-size; i<=size; i+=1){
+				for(var i=-size; i<=size; i+=10){
 					if(i == 0){
 						axes.vertices.push(new THREE.Vector3(-size, -0.04, i));
 						axes.vertices.push(new THREE.Vector3(size, -0.04, i));

--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
 
 				camera=new THREE.PerspectiveCamera(45, window.innerWidth/window.innerHeight, 1, 1000);
 				camera.position.y=75;
-				camera.position.z=5;
+				//camera.position.z=5;
 
 				renderer=new THREE.WebGLRenderer();
 				renderer.setSize(window.innerWidth, window.innerHeight)

--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
 
 				camera=new THREE.PerspectiveCamera(45, window.innerWidth/window.innerHeight, 1, 1000);
 				camera.position.y=75;
-				//camera.position.z=5;
+				camera.position.z=500;
 
 				renderer=new THREE.WebGLRenderer();
 				renderer.setSize(window.innerWidth, window.innerHeight);

--- a/index.html
+++ b/index.html
@@ -108,11 +108,8 @@
 				}
 
 				var geometry=new THREE.Geometry();
-				geometry.verticesNeedUpdate=true;
-
 				var spline=new THREE.SplineCurve3(points);
 				var splinePoints=spline.getPoints(points.length-1);
-
 				for(i=0; i<splinePoints.length; i++){
 					if(Math.abs((spline.points[i]).z)<=size){
 						geometry.vertices.push(spline.points[i]);
@@ -144,7 +141,7 @@
 					return;
 				}
 
-				if(boundY1>boundY2){  //Switch the bounds around so that the for loop works
+				if(this.bound1>this.bound2){  //Switch the bounds around so that the for loop works
 					var temp=this.bound2;
 					this.bound2=this.bound1;
 					this.bound1=temp;
@@ -165,19 +162,19 @@
 								console.log("			Both boundY1 and boundY2 are greater than or equal to 0");
 								if(graph2ComparingPoint1>graph1ComparingPoint1 && graph2ComparingPoint2>graph1ComparingPoint2){
 									console.log("					Graph2 is higher than graph1");
-									this.addBSP("this.axisOfRotation-graphArray[1].getY(i)", "this.axisOfRotation-graphArray[1].getY(i+0.5)", "this.axisOfRotation-this.getY(i)", "this.axisOfRotation-this.getY(i+0.5)");
+									this.addBSP("this.axisOfRotation-graphArray[1].getY(i)", "this.axisOfRotation-graphArray[1].getY(i+step)", "this.axisOfRotation-this.getY(i)", "this.axisOfRotation-this.getY(i+step)");
 								} else {
 									console.log("					Graph2 is lower than or equal to graph1");
-									this.addBSP("this.axisOfRotation-this.getY(i)", "this.axisOfRotation-this.getY(i+0.5)", "this.axisOfRotation-graphArray[1].getY(i)", "this.axisOfRotation-graphArray[1].getY(i+0.5)");
+									this.addBSP("this.axisOfRotation-this.getY(i)", "this.axisOfRotation-this.getY(i+step)", "this.axisOfRotation-graphArray[1].getY(i)", "this.axisOfRotation-graphArray[1].getY(i+step)");
 								}
 							} else {
 								console.log("			One of the bounds is less than 0");
 								if(graph2ComparingPoint1>graph1ComparingPoint1 && graph2ComparingPoint2>graph1ComparingPoint2){
 									console.log("					Graph2 is higher than graph1");
-									this.addBSP("this.axisOfRotation+Math.abs(graphArray[1].getY(i))", "this.axisOfRotation+Math.abs(graphArray[1].getY(i+0.5))", "this.axisOfRotation-this.getY(i)", "this.axisOfRotation-this.getY(i+0.5)");
+									this.addBSP("this.axisOfRotation+Math.abs(graphArray[1].getY(i))", "this.axisOfRotation+Math.abs(graphArray[1].getY(i+step))", "this.axisOfRotation-this.getY(i)", "this.axisOfRotation-this.getY(i+step)");
 								} else {
 									console.log("					Graph2 is lower than or equal to graph1");
-									this.addBSP("this.axisOfRotation-this.getY(i)", "this.axisOfRotation-this.getY(i+0.5)", "this.axisOfRotation-graphArray[1].getY(i)", "this.axisOfRotation-graphArray[1].getY(i+0.5)");
+									this.addBSP("this.axisOfRotation-this.getY(i)", "this.axisOfRotation-this.getY(i+step)", "this.axisOfRotation-graphArray[1].getY(i)", "this.axisOfRotation-graphArray[1].getY(i+step)");
 								}
 							}
 						} else if(this.axisOfRotation<=boundY1 && this.axisOfRotation<=graphArray[1].getY(this.bound1)){
@@ -186,19 +183,19 @@
 								console.log("			Both boundY1 and boundY2 are greater than or equal to 0");
 								if(graph2ComparingPoint1>graph1ComparingPoint1 && graph2ComparingPoint2>graph1ComparingPoint2){
 									console.log("					Graph2 is higher than graph1");
-									this.addBSP("Math.abs(this.axisOfRotation)+this.getY(i)", "Math.abs(this.axisOfRotation)+this.getY(i+0.5)", "Math.abs(this.axisOfRotation)+graphArray[1].getY(i)", "Math.abs(this.axisOfRotation)+graphArray[1].getY(i+0.5)");
+									this.addBSP("Math.abs(this.axisOfRotation)+this.getY(i)", "Math.abs(this.axisOfRotation)+this.getY(i+step)", "Math.abs(this.axisOfRotation)+graphArray[1].getY(i)", "Math.abs(this.axisOfRotation)+graphArray[1].getY(i+step)");
 								} else {
 									console.log("					Graph2 is lower than or equal to graph1");
-									this.addBSP("Math.abs(this.axisOfRotation)+graphArray[1].getY(i)", "Math.abs(this.axisOfRotation)+graphArray[1].getY(i+0.5)", "Math.abs(this.axisOfRotation)+this.getY(i)", "Math.abs(this.axisOfRotation)+this.getY(i+0.5)");
+									this.addBSP("Math.abs(this.axisOfRotation)+graphArray[1].getY(i)", "Math.abs(this.axisOfRotation)+graphArray[1].getY(i+step)", "Math.abs(this.axisOfRotation)+this.getY(i)", "Math.abs(this.axisOfRotation)+this.getY(i+step)");
 								}
 							} else {
 								console.log("			One of the bounds is less than 0");
 								if(graph2ComparingPoint1>graph1ComparingPoint1 && graph2ComparingPoint2>graph1ComparingPoint2){
 									console.log("					Graph2 is higher than graph1");
-									this.addBSP("Math.abs(this.axisOfRotation-this.getY(i))", "Math.abs(this.axisOfRotation-this.getY(i+0.5))", "Math.abs(this.axisOfRotation-graphArray[1].getY(i))", "Math.abs(this.axisOfRotation-graphArray[1].getY(i+0.5))");
+									this.addBSP("Math.abs(this.axisOfRotation-this.getY(i))", "Math.abs(this.axisOfRotation-this.getY(i+step))", "Math.abs(this.axisOfRotation-graphArray[1].getY(i))", "Math.abs(this.axisOfRotation-graphArray[1].getY(i+step))");
 								} else {
 									console.log("					Graph2 is lower than or equal to graph1");
-									this.addBSP("Math.abs(this.axisOfRotation-graphArray[1].getY(i))", "Math.abs(this.axisOfRotation-graphArray[1].getY(i+0.5))", "Math.abs(this.axisOfRotation-this.getY(i))", "Math.abs(this.axisOfRotation-this.getY(i+0.5))");
+									this.addBSP("Math.abs(this.axisOfRotation-graphArray[1].getY(i))", "Math.abs(this.axisOfRotation-graphArray[1].getY(i+step))", "Math.abs(this.axisOfRotation-this.getY(i))", "Math.abs(this.axisOfRotation-this.getY(i+step))");
 								}
 							}
 						} else {
@@ -211,35 +208,41 @@
 						console.log("		BoundY1 is equal to boundY2 and bound1 does not equal bound2");
 						if(this.axisOfRotation>boundY1){
 							console.log("			Axis of rotation is greater than boundY1");
-							this.addBSP("Math.abs(this.axisOfRotation-this.getY(i))", "Math.abs(this.axisOfRotation-this.getY(i+0.5))", "Math.abs(this.axisOfRotation)", "Math.abs(this.axisOfRotation)");
+							this.addBSP("Math.abs(this.axisOfRotation-this.getY(i))", "Math.abs(this.axisOfRotation-this.getY(i+step))", "Math.abs(this.axisOfRotation)", "Math.abs(this.axisOfRotation)");
 						} else if(this.axisOfRotation<boundY1){
 							console.log("			Axis of rotation is less than boundY1");
-							this.addBSP("Math.abs(this.axisOfRotation)", "Math.abs(this.axisOfRotation)", "Math.abs(this.axisOfRotation)+this.getY(i)", "Math.abs(this.axisOfRotation)+this.getY(i+0.5)");
+							this.addBSP("Math.abs(this.axisOfRotation)", "Math.abs(this.axisOfRotation)", "Math.abs(this.axisOfRotation)+this.getY(i)", "Math.abs(this.axisOfRotation)+this.getY(i+step)");
 						} else if(this.axisOfRotation===boundY1){
 							console.log("			Axis of rotation is equal to boundY1");
-							this.addSolidWithoutHoles("Math.abs(this.getY(i))", "Math.abs(this.getY(i+this.quality))");
+							this.addSolidWithoutHoles("Math.abs(this.getY(i))", "Math.abs(this.getY(i+step))");
 						}
 					}
 				} else {
 					console.log("Axis of rotation is 0");
-					this.addSolidWithoutHoles("Math.abs(this.getY(i))", "Math.abs(this.getY(i+this.quality))");
+					this.addSolidWithoutHoles("Math.abs(this.getY(i))", "Math.abs(this.getY(i+step))");
 				}
 				scene.add(this.group);
 				render();
 			};
 
 			Graph.prototype.addBSP=function(smallGeoR1, smallGeoR2, bigGeoR1, bigGeoR2){
-				for(var i=this.bound1; i<this.bound2; i+=0.5){
+				var step=this.quality;
+				for(var i=this.bound1; i<this.bound2; i+=step){
 					if(this.getY(i)<=size){
 						if(!eval(smallGeoR1) || !eval(smallGeoR2)){  //Hacky bugfix woo
 							smallGeoR1=smallGeoR1 + "+0.01";
 							smallGeoR2=smallGeoR2 + "+0.01";
 						}
 
-						var smallCylinderGeom=new THREE.CylinderGeometry(eval(smallGeoR1), eval(smallGeoR2), 0.5, 50);
-						smallCylinderGeom.applyMatrix(new THREE.Matrix4().makeTranslation(0, i+0.5/2, -this.axisOfRotation));
-						var largeCylinderGeom=new THREE.CylinderGeometry(eval(bigGeoR1), eval(bigGeoR2), 0.5, 360);
-						largeCylinderGeom.applyMatrix(new THREE.Matrix4().makeTranslation(0, i+0.5/2, -this.axisOfRotation));
+						if(i+step>this.bound2)  //Prevent the solid from extending beyond the second bound if it can't be divided by the quality
+						{
+							step=this.bound2-i;
+						}
+
+						var smallCylinderGeom=new THREE.CylinderGeometry(eval(smallGeoR1), eval(smallGeoR2), step, 50);
+						smallCylinderGeom.applyMatrix(new THREE.Matrix4().makeTranslation(0, i+step/2, -this.axisOfRotation));
+						var largeCylinderGeom=new THREE.CylinderGeometry(eval(bigGeoR1), eval(bigGeoR2), step, 360);
+						largeCylinderGeom.applyMatrix(new THREE.Matrix4().makeTranslation(0, i+step/2, -this.axisOfRotation));
 						var smallCylinderBSP=new ThreeBSP(smallCylinderGeom);
 						var largeCylinderBSP=new ThreeBSP(largeCylinderGeom);
 						var intersectionBSP=largeCylinderBSP.subtract(smallCylinderBSP);
@@ -252,11 +255,16 @@
 			};
 
 			Graph.prototype.addSolidWithoutHoles=function(leftRadius, rightRadius){
-				for(var i=this.bound1; i<this.bound2; i+=this.quality){
+				var step=this.quality;
+				for(var i=this.bound1; i<this.bound2; i+=step){
 					if(this.getY(i)<=size){
-						var geometry=new THREE.CylinderGeometry(eval(leftRadius), eval(rightRadius), this.quality, 100);
-						geometry.verticesNeedUpdate=true;
-						geometry.applyMatrix(new THREE.Matrix4().makeTranslation(0, -(i+this.quality/2), -this.axisOfRotation));
+						if(i+step>this.bound2)  //Prevent the solid from extending beyond the second bound if it can't be divided by the quality
+						{
+							step=this.bound2-i;
+						}
+
+						var geometry=new THREE.CylinderGeometry(eval(leftRadius), eval(rightRadius), step, 100);
+						geometry.applyMatrix(new THREE.Matrix4().makeTranslation(0, -(i+step/2), -this.axisOfRotation));
 
 						var material=new THREE.MeshPhongMaterial({color: 0xffff00/*, transparent: true, opacity: 0.5*/});
 						var plane=new THREE.Mesh(geometry, material);
@@ -353,10 +361,7 @@
 
 			function addAxis(){
 				var geometry=new THREE.Geometry();
-				geometry.verticesNeedUpdate=true;
-
 				var axes=new THREE.Geometry();
-				axes.verticesNeedUpdate=true;
 
 				for(var i=-size; i<=size; i+=10){
 					if(i){

--- a/index.html
+++ b/index.html
@@ -100,6 +100,7 @@
 				for(var i=-size; i<=size; i+=step){
 					if(this.given!==null){
 						func=(eval(this.given));
+					}
 
 					points[counter+size]=new THREE.Vector3(x.toFixed(2), 0, func);
 					x+=step;

--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
 				//camera.position.z=5;
 
 				renderer=new THREE.WebGLRenderer();
-				renderer.setSize(window.innerWidth, window.innerHeight)
+				renderer.setSize(window.innerWidth, window.innerHeight);
 				document.body.appendChild(renderer.domElement);
 
 				controls=new THREE.TrackballControls(camera, renderer.domElement);
@@ -99,7 +99,7 @@
 				var step=0.01;
 				for(var i=-size; i<=size; i+=step){
 					if(this.given!=null){
-						this.func=-(eval(this.given));  //Somehow the plane is upside-down: the positive y-cordinate is negative
+						this.func=(eval(this.given));
 					}
 
 					points[counter+size]=new THREE.Vector3(x.toFixed(2), 0, this.func);
@@ -238,9 +238,9 @@
 					if(this.getY(i)<=size){
 						var geometry=new THREE.CylinderGeometry(eval(leftRadius), eval(rightRadius), quality, 100);
 						geometry.verticesNeedUpdate=true;
-						geometry.applyMatrix(new THREE.Matrix4().makeTranslation(0, -(i+quality/2), -axisOfRotation));
+						geometry.applyMatrix(new THREE.Matrix4().makeTranslation(0, i+quality/2, -axisOfRotation));
 
-						var material=new THREE.MeshPhongMaterial({color: 0xffff00/*, transparent: true, opacity: 0.5*/});
+						var material=new THREE.MeshPhongMaterial({color: 0xffff00, transparent: true, opacity: 0.5});
 						var plane=new THREE.Mesh(geometry, material);
 						plane.material.color.setHex(0xffff00);
 
@@ -258,13 +258,13 @@
 							smallGeoR2=smallGeoR2 + "+0.01";
 						}
 						var smallCylinderGeom=new THREE.CylinderGeometry(eval(smallGeoR1), eval(smallGeoR2), 0.5, smallSeg);
-						smallCylinderGeom.applyMatrix(new THREE.Matrix4().makeTranslation(0, -(i+0.5/2), -axisOfRotation));
+						smallCylinderGeom.applyMatrix(new THREE.Matrix4().makeTranslation(0, i+0.5/2, -axisOfRotation));
 						var largeCylinderGeom=new THREE.CylinderGeometry(eval(bigGeoR1), eval(bigGeoR2), 0.5, bigSeg);
-						largeCylinderGeom.applyMatrix(new THREE.Matrix4().makeTranslation(0, -(i+0.5/2), -axisOfRotation));
+						largeCylinderGeom.applyMatrix(new THREE.Matrix4().makeTranslation(0, i+0.5/2, -axisOfRotation));
 						var smallCylinderBSP=new ThreeBSP(smallCylinderGeom);
 						var largeCylinderBSP=new ThreeBSP(largeCylinderGeom);
 						var intersectionBSP=largeCylinderBSP.subtract(smallCylinderBSP);
-						var material=new THREE.MeshPhongMaterial({color: 0xffff00/*, transparent: true, opacity: 0.5*/});
+						var material=new THREE.MeshPhongMaterial({color: 0xffff00, transparent: true, opacity: 0.5});
 						var hollowCylinder=intersectionBSP.toMesh(material);
 						hollowCylinder.rotation.set(0, 0, Math.PI/2);
 						this.group.add(hollowCylinder);


### PR DESCRIPTION
:rotating_light: :warning: **DO NOT MERGE, THIS IS CURRENTLY IN THE EXPERIMENTATION STAGE** :warning: :rotating_light:
Currently, we're setting `camera.position.z` to 5 when the camera first initializes.  This causes (at least) 2 bugs: #10 and #15.  However, removing this line causes another bug: click-dragging breaks.

This PR aims to fix the listed bugs while not introducing any new ones.

Fixes #10
Fixes #15
