### PR TITLE
Use math.eval instead of eval for parsing functions

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,6 @@
 		<button type="button" onclick="submit()">Rotate!</button>
 		<!-- <input id="rotate" type="range" onchange="rotate()" min="0" max="360" value="360" step="30"/> -->
 
-		<a>Make sure to type the function in a <a href="http://www.w3schools.com/jsref/jsref_obj_math.asp" target="_blank">programming format</a>.  For example, 2x+3 is <b>2*x+3</b>, and sin(2x) is <b>Math.sin(2*x)</b>.</a>
 		<br>
 		<select id="quality" onchange="submit()">
 			<option value="0.5">Select Quality

--- a/js/graph.js
+++ b/js/graph.js
@@ -47,7 +47,7 @@ Graph.prototype.getY=function(x){  //jshint ignore:line
 Graph.prototype.getVertex=function(){
 	var points=[];
 	for(var x=this.bound1; x<=this.bound2; x+=0.01){
-		points[x]=eval(this.given);
+		points[x]=math.eval(this.given, {x: x});
 	}
 	return (this.getY(this.bound1+0.01) > 0 && this.getY(this.bound2-0.01) > 0 ? Math.max.apply(null, points) : Math.min.apply(null, points));
 };

--- a/js/graph.js
+++ b/js/graph.js
@@ -41,7 +41,7 @@ function Graph(given, bound1, bound2, axisOfRotation, quality, graphID){
 }
 
 Graph.prototype.getY=function(x){  //jshint ignore:line
-	return eval(this.given);
+	return math.eval(this.given, {x: x});
 };
 
 Graph.prototype.getVertex=function(){
@@ -60,7 +60,7 @@ Graph.prototype.draw=function(){
 	var equation;
 	for(var i=-size; i<=size; i+=step){
 		if(this.given!==null){
-			equation=-eval(this.given);  //Somehow the plane is upside-down: the positive y-cordinate is negative
+			equation=-math.eval(this.given, {x: i});  //Somehow the plane is upside-down: the positive y-cordinate is negative
 		}
 
 		points[counter+size]=new THREE.Vector3(x.toFixed(2), 0, equation);
@@ -239,7 +239,7 @@ function clearGraph(){
 	render();
 }
 
-function submit(){  //jshint ignore:line
+function submit(){
 	clearGraph();
 
 	//TODO: Being lazy for now, I'll change this later. Using eval()
@@ -256,7 +256,7 @@ function submit(){  //jshint ignore:line
 	}
 	catch(error)
 	{
-		var type=(isNaN(bound1) ? "first bound" : isNaN(bound2) ? "second bound" : "axis of rotation");
+		const type=(isNaN(bound1) ? "first bound" : isNaN(bound2) ? "second bound" : "axis of rotation");
 		sweetAlert("Invalid " + type, "Please enter a valid number for the " + type, "warning");
 		return;
 	}
@@ -268,7 +268,7 @@ function submit(){  //jshint ignore:line
 	}
 	else if(bound1===undefined || bound2===undefined || axisOfRotation===undefined)
 	{
-		var type=(bound1===undefined ? "first bound" : bound2===undefined ? "second bound" : "axis of rotation");
+		const type=(bound1===undefined ? "first bound" : bound2===undefined ? "second bound" : "axis of rotation");
 		sweetAlert("Missing " + type, "Please specify the " + type, "warning");
 		return;
 	}


### PR DESCRIPTION
Removes the need to supply `x*x*x` for `x^3` or `Math.sin(x)` for `sin(x)`.  :tada:

Also changed a type to a constant in order to get rid of an annoying linter error.
