### PR TITLE
Dispose of geometries

### DIFF
--- a/js/graph.js
+++ b/js/graph.js
@@ -312,6 +312,8 @@ Graph.prototype.addBSP = function(smallGeoR1, smallGeoR2, bigGeoR1, bigGeoR2)
 			largeCylinderGeom.translate(0, -(i + step / 2), this.axisOfRotation).rotateZ(Math.PI / 2);
 			var smallCylinderBSP = new ThreeBSP(smallCylinderGeom);
 			var largeCylinderBSP = new ThreeBSP(largeCylinderGeom);
+			smallCylinderGeom.dispose();
+			largeCylinderGeom.dispose();
 			var intersectionBSP = largeCylinderBSP.subtract(smallCylinderBSP);
 			var hollowCylinder = intersectionBSP.toMesh(new THREE.MeshPhongMaterial({color: 0xFFFF00/*, transparent: true, opacity: 0.5*/}));
 			this.group.add(hollowCylinder);
@@ -334,6 +336,7 @@ Graph.prototype.addSolidWithoutHoles = function(leftRadius, rightRadius)
 			var geometry = new THREE.CylinderGeometry(eval(leftRadius), eval(rightRadius), step, 100);
 			geometry.translate(0, -(i + step / 2), this.axisOfRotation).rotateZ(Math.PI / 2);
 			var plane = new THREE.Mesh(geometry, new THREE.MeshPhongMaterial({color: 0xFFFF00/*, transparent: true, opacity: 0.5*/}));
+			geometry.dispose();
 			this.group.add(plane);
 		}
 	}


### PR DESCRIPTION
This prevents memory leaks.  I'm not sure if BSPs need disposing of but I wasn't able to find a function to do so, so hopefully not.
