### PR TITLE
Put cylinders in the correct graphing plane before translating

### DIFF
--- a/js/graph.js
+++ b/js/graph.js
@@ -307,9 +307,9 @@ Graph.prototype.addBSP = function(smallGeoR1, smallGeoR2, bigGeoR1, bigGeoR2)
 			}
 
 			var smallCylinderGeom = new THREE.CylinderGeometry(eval(smallGeoR1), eval(smallGeoR2), step, 50);
-			smallCylinderGeom.translate(0, -(i + step / 2), this.axisOfRotation).rotateZ(Math.PI / 2);
+			smallCylinderGeom.rotateZ(Math.PI / 2).translate(i + step / 2, this.axisOfRotation, 0);
 			var largeCylinderGeom = new THREE.CylinderGeometry(eval(bigGeoR1), eval(bigGeoR2), step, 360);
-			largeCylinderGeom.translate(0, -(i + step / 2), this.axisOfRotation).rotateZ(Math.PI / 2);
+			largeCylinderGeom.rotateZ(Math.PI / 2).translate(i + step / 2, this.axisOfRotation, 0);
 			var smallCylinderBSP = new ThreeBSP(smallCylinderGeom);
 			var largeCylinderBSP = new ThreeBSP(largeCylinderGeom);
 			smallCylinderGeom.dispose();
@@ -334,7 +334,7 @@ Graph.prototype.addSolidWithoutHoles = function(leftRadius, rightRadius)
 			}
 
 			var geometry = new THREE.CylinderGeometry(eval(leftRadius), eval(rightRadius), step, 100);
-			geometry.translate(0, -(i + step / 2), this.axisOfRotation).rotateZ(Math.PI / 2);
+			geometry.rotateZ(Math.PI / 2).translate(i + step / 2, this.axisOfRotation, 0);
 			var plane = new THREE.Mesh(geometry, new THREE.MeshPhongMaterial({color: 0xFFFF00/*, transparent: true, opacity: 0.5*/}));
 			geometry.dispose();
 			this.group.add(plane);


### PR DESCRIPTION
Now x, y, and z actually make intuitive(TM) sense!

Fixes a major bug where everything would be rotated around 0 which was introduced in #39.
