### PR TITLE
Clear graph caches on reset/submit

### DIFF
--- a/js/graph.js
+++ b/js/graph.js
@@ -362,6 +362,9 @@ function submit() // eslint-disable-line
 {
 	clearGraph();
 
+	graphArray[0] = undefined;
+	graphArray[1] = undefined;
+
 	var function1 = document.getElementById("function1").value;
 	var function2 = document.getElementById("function2").value;
 	var quality = Number(document.getElementById("quality").value);
@@ -472,6 +475,9 @@ function reset()  //eslint-disable-line
 {
 	clearGraph();
 	controls.reset();
+
+	graphArray[0] = undefined;
+	graphArray[1] = undefined;
 
 	document.getElementById("function1").value = "";
 	document.getElementById("function2").value = "";


### PR DESCRIPTION
This prevents the second graph from still existing if it was present in the previous rotation but then cleared.

Test case:
1. Enter x, x^2, 0, 1, 0 and rotate
2. Enter x, [blank], 0, 5, 0 and rotate

Expected: Rotates x around 0 and 5
Actual (before this PR): Detects intersection at x=1
