### PR TITLE
Use ES6 features

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -46,6 +46,8 @@ rules:
                     after: true
                 throw:
                     after: true
+                var:
+                    after: true
     new-cap: 1
     new-parens: 2
     no-array-constructor: 2

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -42,6 +42,8 @@ rules:
             overrides:
                 case:
                     after: true
+                const:
+                    after: true
                 return:
                     after: true
                 throw:

--- a/js/graph.js
+++ b/js/graph.js
@@ -1,7 +1,7 @@
 "use strict";
-var camera, controls, scene, renderer;
-var size = 28;
-var graphArray = [];
+let camera, controls, scene, renderer;
+const size = 28;
+let graphArray = [];
 
 init();
 
@@ -13,11 +13,11 @@ function init()
 		return;
 	}
 
-	var formID = document.getElementById("form");
-	var wipID = document.getElementById("wip");
-	var formHeight = formID.clientHeight + parseInt(window.getComputedStyle(formID).marginTop);  //Bottom is already covered by wip's top margin
-	var wipHeight = wipID.clientHeight + parseInt(window.getComputedStyle(wipID).marginTop) + parseInt(window.getComputedStyle(wipID).marginBottom);
-	var totalHeight = formHeight + wipHeight;
+	const formID = document.getElementById("form");
+	const wipID = document.getElementById("wip");
+	const formHeight = formID.clientHeight + parseInt(window.getComputedStyle(formID).marginTop);  //Bottom is already covered by wip's top margin
+	const wipHeight = wipID.clientHeight + parseInt(window.getComputedStyle(wipID).marginTop) + parseInt(window.getComputedStyle(wipID).marginBottom);
+	const totalHeight = formHeight + wipHeight;
 
 	scene = new THREE.Scene();
 
@@ -39,9 +39,9 @@ function init()
 
 function getPoints(equation)
 {
-	var points = [];
-	var compiledEquation = math.compile(equation);
-	for(var x = -size; x <= size + 1; x += 0.01)  //Add 1 to the ending size because of the origin
+	let points = [];
+	const compiledEquation = math.compile(equation);
+	for(let x = -size; x <= size + 1; x += 0.01)  //Add 1 to the ending size because of the origin
 	{
 		points.push(compiledEquation.eval({x}));
 	}
@@ -50,10 +50,10 @@ function getPoints(equation)
 
 function getIntersections(points1, points2, bound1, bound2)
 {
-	var intersections = [];
-	var larger;
+	let intersections = [];
+	let larger;
 
-	for(var x = math.round(100 * (size + bound1)); x < 100 * (size + bound2); x++)
+	for(let x = math.round(100 * (size + bound1)); x < 100 * (size + bound2); x++)
 	{
 		if(points1[x] > points2[x])
 		{
@@ -109,22 +109,21 @@ Graph.prototype.getMin = function()
 
 Graph.prototype.draw = function()
 {
-	var x = -size;
-	var vector = [];
-	var counter = x;  //I'll change this later, just using a counter variable for now
-	var step = 0.01;
-	var i;
-	for(i = -size; i <= size; i += step)
+	let x = -size;
+	let vector = [];
+	let counter = x;  //I'll change this later, just using a counter variable for now
+	const step = 0.01;
+	for(let i = -size; i <= size; i += step)
 	{
 		vector[counter + size] = new THREE.Vector3(x.toFixed(2), this.points[counter + size], 0.05);
 		x += step;
 		counter++;
 	}
 
-	var geometry = new THREE.Geometry();
-	var spline = new THREE.CatmullRomCurve3(vector);
-	var splinePoints = spline.getPoints(vector.length - 1);
-	for(i = 0; i < splinePoints.length; i++)
+	const geometry = new THREE.Geometry();
+	const spline = new THREE.CatmullRomCurve3(vector);
+	const splinePoints = spline.getPoints(vector.length - 1);
+	for(let i = 0; i < splinePoints.length; i++)
 	{
 		if(Math.abs(spline.points[i].y) <= size)
 		{
@@ -132,7 +131,7 @@ Graph.prototype.draw = function()
 		}
 	}
 
-	var graph = new THREE.Line(geometry, new THREE.LineBasicMaterial());
+	const graph = new THREE.Line(geometry, new THREE.LineBasicMaterial());
 	graph.name = "graph";
 	scene.add(graph);
 	render();
@@ -141,8 +140,8 @@ Graph.prototype.draw = function()
 Graph.prototype.drawShape = function()
 {
 	this.group.name = "solid";
-	var boundY1 = this.getY(this.bound1);
-	var boundY2 = this.getY(this.bound2);
+	let boundY1 = this.getY(this.bound1);
+	let boundY2 = this.getY(this.bound2);
 
 	if(this.bound1 === this.bound2)
 	{
@@ -157,7 +156,7 @@ Graph.prototype.drawShape = function()
 		[boundY1, boundY2] = [boundY2, boundY1];
 	}
 
-	var [intersections, larger] = getIntersections(this.points, graphArray[1] ? graphArray[1].points : Array(100 * size * 2 + 1).fill(this.axisOfRotation), this.bound1, this.bound2);
+	const [intersections, larger] = getIntersections(this.points, graphArray[1] ? graphArray[1].points : Array(100 * size * 2 + 1).fill(this.axisOfRotation), this.bound1, this.bound2);
 
 	if(intersections[0] !== undefined)
 	{
@@ -227,8 +226,8 @@ Graph.prototype.drawShape = function()
 
 Graph.prototype.addBSP = function(smallGeoR1, smallGeoR2, bigGeoR1, bigGeoR2)
 {
-	var step = this.quality;
-	for(var i = this.bound1; i < this.bound2; i += step)
+	let step = this.quality;
+	for(let i = this.bound1; i < this.bound2; i += step)
 	{
 		if(this.getY(i) <= size)
 		{
@@ -243,16 +242,16 @@ Graph.prototype.addBSP = function(smallGeoR1, smallGeoR2, bigGeoR1, bigGeoR2)
 				step = this.bound2 - i;
 			}
 
-			var smallCylinderGeom = new THREE.CylinderGeometry(eval(smallGeoR1), eval(smallGeoR2), step, 50);
+			const smallCylinderGeom = new THREE.CylinderGeometry(eval(smallGeoR1), eval(smallGeoR2), step, 50);
 			smallCylinderGeom.rotateZ(Math.PI / 2).translate(i + step / 2, this.axisOfRotation, 0);
-			var largeCylinderGeom = new THREE.CylinderGeometry(eval(bigGeoR1), eval(bigGeoR2), step, 360);
+			const largeCylinderGeom = new THREE.CylinderGeometry(eval(bigGeoR1), eval(bigGeoR2), step, 360);
 			largeCylinderGeom.rotateZ(Math.PI / 2).translate(i + step / 2, this.axisOfRotation, 0);
-			var smallCylinderBSP = new ThreeBSP(smallCylinderGeom);
-			var largeCylinderBSP = new ThreeBSP(largeCylinderGeom);
+			const smallCylinderBSP = new ThreeBSP(smallCylinderGeom);
+			const largeCylinderBSP = new ThreeBSP(largeCylinderGeom);
 			smallCylinderGeom.dispose();
 			largeCylinderGeom.dispose();
-			var intersectionBSP = largeCylinderBSP.subtract(smallCylinderBSP);
-			var hollowCylinder = intersectionBSP.toMesh(new THREE.MeshPhongMaterial({color: 0xFFFF00/*, transparent: true, opacity: 0.5*/}));
+			const intersectionBSP = largeCylinderBSP.subtract(smallCylinderBSP);
+			const hollowCylinder = intersectionBSP.toMesh(new THREE.MeshPhongMaterial({color: 0xFFFF00/*, transparent: true, opacity: 0.5*/}));
 			this.group.add(hollowCylinder);
 		}
 	}
@@ -260,8 +259,8 @@ Graph.prototype.addBSP = function(smallGeoR1, smallGeoR2, bigGeoR1, bigGeoR2)
 
 Graph.prototype.addSolidWithoutHoles = function(leftRadius, rightRadius)
 {
-	var step = this.quality;
-	for(var i = this.bound1; i < this.bound2; i += step)
+	let step = this.quality;
+	for(let i = this.bound1; i < this.bound2; i += step)
 	{
 		if(this.getY(i) <= size)
 		{
@@ -270,9 +269,9 @@ Graph.prototype.addSolidWithoutHoles = function(leftRadius, rightRadius)
 				step = this.bound2 - i;
 			}
 
-			var geometry = new THREE.CylinderGeometry(eval(leftRadius), eval(rightRadius), step, 100);
+			const geometry = new THREE.CylinderGeometry(eval(leftRadius), eval(rightRadius), step, 100);
 			geometry.rotateZ(Math.PI / 2).translate(i + step / 2, this.axisOfRotation, 0);
-			var plane = new THREE.Mesh(geometry, new THREE.MeshPhongMaterial({color: 0xFFFF00/*, transparent: true, opacity: 0.5*/}));
+			const plane = new THREE.Mesh(geometry, new THREE.MeshPhongMaterial({color: 0xFFFF00/*, transparent: true, opacity: 0.5*/}));
 			geometry.dispose();
 			this.group.add(plane);
 		}
@@ -281,7 +280,7 @@ Graph.prototype.addSolidWithoutHoles = function(leftRadius, rightRadius)
 
 function clearGraph()
 {
-	for(var i = 0; i < scene.children.length; i++)
+	for(let i = 0; i < scene.children.length; i++)
 	{
 		if(scene.children[i] !== undefined)
 		{
@@ -302,12 +301,12 @@ function submit() // eslint-disable-line
 	graphArray[0] = undefined;
 	graphArray[1] = undefined;
 
-	var function1 = document.getElementById("function1").value;
-	var function2 = document.getElementById("function2").value;
-	var quality = Number(document.getElementById("quality").value);
-	var drawSolid = true;
+	const function1 = document.getElementById("function1").value;
+	const function2 = document.getElementById("function2").value;
+	const quality = Number(document.getElementById("quality").value);
+	let drawSolid = true;
 
-	var bound1, bound2, axisOfRotation;  //Prevents users from passing in undefined variables (eg 'x')
+	let bound1, bound2, axisOfRotation;  //Prevents users from passing in undefined variables (eg 'x')
 	try
 	{
 		bound1 = math.eval(document.getElementById("bound1").value);
@@ -342,9 +341,9 @@ function submit() // eslint-disable-line
 		drawSolid = false;
 	}
 
-	var points = getPoints(function1);
+	let points = getPoints(function1);
 
-	var graph1 = new Graph(function1, bound1, bound2, axisOfRotation, points, quality, 0);
+	const graph1 = new Graph(function1, bound1, bound2, axisOfRotation, points, quality, 0);
 	graphArray[graph1.graphID] = graph1;
 	graph1.draw();
 
@@ -352,7 +351,7 @@ function submit() // eslint-disable-line
 	{
 		points = getPoints(function2);
 
-		var graph2 = new Graph(function2, bound1, bound2, axisOfRotation, points, quality, 1);
+		const graph2 = new Graph(function2, bound1, bound2, axisOfRotation, points, quality, 1);
 		graphArray[graph2.graphID] = graph2;
 		graph2.draw();
 	}
@@ -376,7 +375,7 @@ function render()
 
 function addLights()
 {
-	var pointLight = new THREE.PointLight(0xFFFF00, 1, 5000);
+	const pointLight = new THREE.PointLight(0xFFFF00, 1, 5000);
 	pointLight.position.set(0, 100, 90);
 	scene.add(pointLight);
 	scene.add(new THREE.HemisphereLight(0x3284FF, 0xFFC87F, 0.6));
@@ -384,9 +383,9 @@ function addLights()
 
 function addAxis()
 {
-	var lines = new THREE.Geometry();
-	var axes = new THREE.Geometry();
-	for(var i = -size; i <= size; i++)
+	const lines = new THREE.Geometry();
+	const axes = new THREE.Geometry();
+	for(let i = -size; i <= size; i++)
 	{
 		if(i)
 		{
@@ -426,11 +425,11 @@ function reset()  //eslint-disable-line
 
 window.onresize = function()
 {
-	var formID = document.getElementById("form");
-	var wipID = document.getElementById("wip");
-	var formHeight = formID.clientHeight + parseInt(window.getComputedStyle(formID).marginTop);  //Bottom is already covered by wip's top margin
-	var wipHeight = wipID.clientHeight + parseInt(window.getComputedStyle(wipID).marginTop) + parseInt(window.getComputedStyle(wipID).marginBottom);
-	var totalHeight = formHeight + wipHeight;
+	const formID = document.getElementById("form");
+	const wipID = document.getElementById("wip");
+	const formHeight = formID.clientHeight + parseInt(window.getComputedStyle(formID).marginTop);  //Bottom is already covered by wip's top margin
+	const wipHeight = wipID.clientHeight + parseInt(window.getComputedStyle(wipID).marginTop) + parseInt(window.getComputedStyle(wipID).marginBottom);
+	const totalHeight = formHeight + wipHeight;
 
 	camera.aspect = window.innerWidth / (window.innerHeight - totalHeight);
 	camera.updateProjectionMatrix();

--- a/js/graph.js
+++ b/js/graph.js
@@ -153,23 +153,11 @@ Graph.prototype.drawShape = function()
 
 	if(this.bound1 > this.bound2)  //Switch the bounds around so that the for loop works
 	{
-		//TODO: Use ES6 destructuring here when it becomes widely available among modern browsers
-		//[bound1, bound2] = [bound2, bound1];
-		//[boundY1, boundY2] = [boundY2, boundY1];
-		var temp = this.bound2;
-		this.bound2 = this.bound1;
-		this.bound1 = temp;
-
-		temp = boundY2;
-		boundY2 = boundY1;
-		boundY1 = temp;
+		[this.bound1, this.bound2] = [this.bound2, this.bound1];
+		[boundY1, boundY2] = [boundY2, boundY1];
 	}
 
-	//TODO: Use ES6 destructuring here when it becomes widely available among modern browsers
-	//var [intersections, larger] = getIntersections(this.points, graphArray[1].points, this.bound1, this.bound2);
-	var result = getIntersections(this.points, graphArray[1] ? graphArray[1].points : Array(100 * size * 2 + 1).fill(this.axisOfRotation), this.bound1, this.bound2);
-	var intersections = result[0];
-	var larger = result[1];
+	var [intersections, larger] = getIntersections(this.points, graphArray[1] ? graphArray[1].points : Array(100 * size * 2 + 1).fill(this.axisOfRotation), this.bound1, this.bound2);
 
 	if(intersections[0] !== undefined)
 	{
@@ -181,16 +169,8 @@ Graph.prototype.drawShape = function()
 	//Switch the functions around so that the larger one is always first for consistency
 	if(!larger && graphArray[1] !== undefined && Number(graphArray[1].given) !== this.axisOfRotation)
 	{
-		//TODO: Use ES6 destructuring here when it becomes widely available among modern browsers
-		//[this.given, graphArray[1].given] = [graphArray[1].given, this.given];
-		//[this.points, graphArray[1].points] = [graphArray[1].points, this.points];
-		var temp2 = graphArray[1].given;
-		graphArray[1].given = this.given;
-		this.given = temp2;
-
-		temp2 = graphArray[1].points;
-		graphArray[1].points = this.points;
-		this.points = temp2;
+		[this.given, graphArray[1].given] = [graphArray[1].given, this.given];
+		[this.points, graphArray[1].points] = [graphArray[1].points, this.points];
 	}
 
 	if(graphArray[1] === undefined || Number(graphArray[1].given) === this.axisOfRotation)  //FIXME: This doesn't catch constants

--- a/js/graph.js
+++ b/js/graph.js
@@ -29,12 +29,12 @@ function init()
 	document.body.appendChild(renderer.domElement);
 
 	controls = new THREE.TrackballControls(camera, renderer.domElement);
-	controls.addEventListener("change", render);
+	controls.addEventListener("change", Graph.render);
 
-	addAxis();
-	addLights();
-	animate();
-	render();
+	Graph.addAxis();
+	Graph.addLights();
+	Graph.animate();
+	Graph.render();
 }
 
 function getPoints(equation)
@@ -80,223 +80,274 @@ function getIntersections(points1, points2, bound1, bound2)
 	return [intersections, larger];
 }
 
-function Graph(given, bound1, bound2, axisOfRotation, points, quality, graphID)
+class Graph
 {
-	this.given = given;
-	this.group = new THREE.Object3D();
-	this.bound1 = bound1;
-	this.bound2 = bound2;
-	this.axisOfRotation = axisOfRotation;
-	this.points = points;
-	this.quality = quality;
-	this.graphID = graphID;
-}
-
-Graph.prototype.getY = function(x)
-{
-	return this.points[Math.round(100 * (size + x))];  //getPoints iterates by 0.01 starting from 0, not -28, so multiply the converted x coord by 100 to get actual indices
-};
-
-Graph.prototype.getMax = function()
-{
-	return math.max(...this.points.slice(100 * (size + this.bound1), 100 * (size + this.bound2) + 1));  //Add 1 to the ending index because splice is exclusive
-};
-
-Graph.prototype.getMin = function()
-{
-	return math.min(...this.points.slice(100 * (size + this.bound1), 100 * (size + this.bound2) + 1));  //Add 1 to the ending index because splice is exclusive
-};
-
-Graph.prototype.draw = function()
-{
-	let x = -size;
-	let vector = [];
-	let counter = x;  //I'll change this later, just using a counter variable for now
-	const step = 0.01;
-	for(let i = -size; i <= size; i += step)
+	constructor(given, bound1, bound2, axisOfRotation, points, quality, graphID)
 	{
-		vector[counter + size] = new THREE.Vector3(x.toFixed(2), this.points[counter + size], 0.05);
-		x += step;
-		counter++;
+		this.given = given;
+		this.group = new THREE.Object3D();
+		this.bound1 = bound1;
+		this.bound2 = bound2;
+		this.axisOfRotation = axisOfRotation;
+		this.points = points;
+		this.quality = quality;
+		this.graphID = graphID;
 	}
 
-	const geometry = new THREE.Geometry();
-	const spline = new THREE.CatmullRomCurve3(vector);
-	const splinePoints = spline.getPoints(vector.length - 1);
-	for(let i = 0; i < splinePoints.length; i++)
+	getY(x)
 	{
-		if(Math.abs(spline.points[i].y) <= size)
+		//getPoints iterates by 0.01 starting from 0, not -28, so multiply the converted x coord by 100 to get actual indices
+		return this.points[Math.round(100 * (size + x))];
+	}
+
+	getMax()
+	{
+		//Add 1 to the ending index because splice is exclusive
+		return math.max(...this.points.slice(100 * (size + this.bound1), 100 * (size + this.bound2) + 1));
+	}
+
+	getMin()
+	{
+		//Add 1 to the ending index because splice is exclusive
+		return math.min(...this.points.slice(100 * (size + this.bound1), 100 * (size + this.bound2) + 1));
+	}
+
+	draw()
+	{
+		let x = -size;
+		let vector = [];
+		let counter = x;  //I'll change this later, just using a counter variable for now
+		const step = 0.01;
+		for(let i = -size; i <= size; i += step)
 		{
-			geometry.vertices.push(spline.points[i]);
+			vector[counter + size] = new THREE.Vector3(x.toFixed(2), this.points[counter + size], 0.05);
+			x += step;
+			counter++;
+		}
+
+		const geometry = new THREE.Geometry();
+		const spline = new THREE.CatmullRomCurve3(vector);
+		const splinePoints = spline.getPoints(vector.length - 1);
+		for(let i = 0; i < splinePoints.length; i++)
+		{
+			if(Math.abs(spline.points[i].y) <= size)
+			{
+				geometry.vertices.push(spline.points[i]);
+			}
+		}
+
+		const graph = new THREE.Line(geometry, new THREE.LineBasicMaterial());
+		graph.name = "graph";
+		scene.add(graph);
+		Graph.render();
+	}
+
+	drawShape()
+	{
+		this.group.name = "solid";
+		let boundY1 = this.getY(this.bound1);
+		let boundY2 = this.getY(this.bound2);
+
+		if(this.bound1 === this.bound2)
+		{
+			sweetAlert("Oh noes!", "We're still working on creating the solid when the bounds are equal.\nSorry about that :(", "warning");
+			Graph.clear();
+			return;
+		}
+
+		if(this.bound1 > this.bound2)  //Switch the bounds around so that the for loop works
+		{
+			[this.bound1, this.bound2] = [this.bound2, this.bound1];
+			[boundY1, boundY2] = [boundY2, boundY1];
+		}
+
+		const [intersections, larger] = getIntersections(this.points, graphArray[1] ? graphArray[1].points : Array(100 * size * 2 + 1).fill(this.axisOfRotation), this.bound1, this.bound2);
+
+		if(intersections[0] !== undefined)
+		{
+			sweetAlert("Invalid bounds", "An intersection point was detected at approximately " + math.round(intersections[0], 2) + " which cannot be between the bounds", "warning");
+			Graph.clear();
+			return;
+		}
+
+		//Switch the functions around so that the larger one is always first for consistency
+		if(!larger && graphArray[1] !== undefined && Number(graphArray[1].given) !== this.axisOfRotation)
+		{
+			[this.given, graphArray[1].given] = [graphArray[1].given, this.given];
+			[this.points, graphArray[1].points] = [graphArray[1].points, this.points];
+		}
+
+		if(graphArray[1] === undefined || Number(graphArray[1].given) === this.axisOfRotation)  //FIXME: This doesn't catch constants
+		{
+			console.log("No second function or second function is equal to the axis of rotation");
+			this.addSolidWithoutHoles("Math.abs(this.getY(i))", "Math.abs(this.getY(i+step))");
+		}
+		else
+		{
+			console.log("Maximums: " + this.getMax() + " and " + graphArray[1].getMax());
+			console.log("Minimums: " + this.getMin() + " and " + graphArray[1].getMin());
+			if(boundY1 !== boundY2)
+			{
+				console.log("\tboundY1 and boundY2 are not equal");
+				if(this.axisOfRotation >= this.getMax() && this.axisOfRotation >= graphArray[1].getMax()
+				|| this.axisOfRotation <= this.getMin() && this.axisOfRotation <= graphArray[1].getMin())
+				{
+					this.addBSP("Math.abs(this.axisOfRotation-graphArray[1].getY(i))",
+					            "Math.abs(this.axisOfRotation-graphArray[1].getY(i+step))",
+					            "Math.abs(this.axisOfRotation-this.getY(i))",
+					            "Math.abs(this.axisOfRotation-this.getY(i+step))");
+				}
+				else
+				{
+					sweetAlert("Oh noes!", "Axis of rotation cannot be between the functions", "warning");
+					Graph.clear();
+					return;
+				}
+			}
+			else if(boundY1 === boundY2)
+			{
+				//Not complete yet (this is just for cylinders)
+				console.log("\t\tBoundY1 is equal to boundY2 and bound1 does not equal bound2");
+				if(this.axisOfRotation > boundY1)
+				{
+					console.log("\t\t\tAxis of rotation is greater than boundY1");
+					this.addBSP("Math.abs(this.axisOfRotation-this.getY(i))", "Math.abs(this.axisOfRotation-this.getY(i+step))", "Math.abs(this.axisOfRotation)", "Math.abs(this.axisOfRotation)");
+				}
+				else if(this.axisOfRotation < boundY1)
+				{
+					console.log("\t\t\tAxis of rotation is less than boundY1");
+					this.addBSP("Math.abs(this.axisOfRotation)", "Math.abs(this.axisOfRotation)", "Math.abs(this.axisOfRotation)+this.getY(i)", "Math.abs(this.axisOfRotation)+this.getY(i+step)");
+				}
+				else if(this.axisOfRotation === boundY1)
+				{
+					console.log("\t\t\tAxis of rotation is equal to boundY1");
+					this.addSolidWithoutHoles("Math.abs(this.getY(i))", "Math.abs(this.getY(i+step))");
+				}
+			}
+		}
+		scene.add(this.group);
+		Graph.render();
+	}
+
+	addBSP(smallGeoR1, smallGeoR2, bigGeoR1, bigGeoR2)
+	{
+		let step = this.quality;
+		for(let i = this.bound1; i < this.bound2; i += step)
+		{
+			if(this.getY(i) <= size)
+			{
+				if(!eval(smallGeoR1) || !eval(smallGeoR2))  //Hacky bugfix woo
+				{
+					smallGeoR1 += "+0.01";
+					smallGeoR2 += "+0.01";
+				}
+
+				if(i + step > this.bound2)  //Prevent the solid from extending beyond the second bound if it can't be divided by the quality
+				{
+					step = this.bound2 - i;
+				}
+
+				const smallCylinderGeom = new THREE.CylinderGeometry(eval(smallGeoR1), eval(smallGeoR2), step, 50);
+				smallCylinderGeom.rotateZ(Math.PI / 2).translate(i + step / 2, this.axisOfRotation, 0);
+				const largeCylinderGeom = new THREE.CylinderGeometry(eval(bigGeoR1), eval(bigGeoR2), step, 360);
+				largeCylinderGeom.rotateZ(Math.PI / 2).translate(i + step / 2, this.axisOfRotation, 0);
+				const smallCylinderBSP = new ThreeBSP(smallCylinderGeom);
+				const largeCylinderBSP = new ThreeBSP(largeCylinderGeom);
+				smallCylinderGeom.dispose();
+				largeCylinderGeom.dispose();
+				const intersectionBSP = largeCylinderBSP.subtract(smallCylinderBSP);
+				const hollowCylinder = intersectionBSP.toMesh(new THREE.MeshPhongMaterial({color: 0xFFFF00/*, transparent: true, opacity: 0.5*/}));
+				this.group.add(hollowCylinder);
+			}
 		}
 	}
 
-	const graph = new THREE.Line(geometry, new THREE.LineBasicMaterial());
-	graph.name = "graph";
-	scene.add(graph);
-	render();
-};
-
-Graph.prototype.drawShape = function()
-{
-	this.group.name = "solid";
-	let boundY1 = this.getY(this.bound1);
-	let boundY2 = this.getY(this.bound2);
-
-	if(this.bound1 === this.bound2)
+	addSolidWithoutHoles(leftRadius, rightRadius)
 	{
-		sweetAlert("Oh noes!", "We're still working on creating the solid when the bounds are equal.\nSorry about that :(", "warning");
-		clearGraph();
-		return;
-	}
-
-	if(this.bound1 > this.bound2)  //Switch the bounds around so that the for loop works
-	{
-		[this.bound1, this.bound2] = [this.bound2, this.bound1];
-		[boundY1, boundY2] = [boundY2, boundY1];
-	}
-
-	const [intersections, larger] = getIntersections(this.points, graphArray[1] ? graphArray[1].points : Array(100 * size * 2 + 1).fill(this.axisOfRotation), this.bound1, this.bound2);
-
-	if(intersections[0] !== undefined)
-	{
-		sweetAlert("Invalid bounds", "An intersection point was detected at approximately " + math.round(intersections[0], 2) + " which cannot be between the bounds", "warning");
-		clearGraph();
-		return;
-	}
-
-	//Switch the functions around so that the larger one is always first for consistency
-	if(!larger && graphArray[1] !== undefined && Number(graphArray[1].given) !== this.axisOfRotation)
-	{
-		[this.given, graphArray[1].given] = [graphArray[1].given, this.given];
-		[this.points, graphArray[1].points] = [graphArray[1].points, this.points];
-	}
-
-	if(graphArray[1] === undefined || Number(graphArray[1].given) === this.axisOfRotation)  //FIXME: This doesn't catch constants
-	{
-		console.log("No second function or second function is equal to the axis of rotation");
-		this.addSolidWithoutHoles("Math.abs(this.getY(i))", "Math.abs(this.getY(i+step))");
-	}
-	else
-	{
-		console.log("Maximums: " + this.getMax() + " and " + graphArray[1].getMax());
-		console.log("Minimums: " + this.getMin() + " and " + graphArray[1].getMin());
-		if(boundY1 !== boundY2)
+		let step = this.quality;
+		for(let i = this.bound1; i < this.bound2; i += step)
 		{
-			console.log("\tboundY1 and boundY2 are not equal");
-			if(this.axisOfRotation >= this.getMax() && this.axisOfRotation >= graphArray[1].getMax()
-			|| this.axisOfRotation <= this.getMin() && this.axisOfRotation <= graphArray[1].getMin())
+			if(this.getY(i) <= size)
 			{
-				this.addBSP("Math.abs(this.axisOfRotation-graphArray[1].getY(i))",
-				            "Math.abs(this.axisOfRotation-graphArray[1].getY(i+step))",
-				            "Math.abs(this.axisOfRotation-this.getY(i))",
-				            "Math.abs(this.axisOfRotation-this.getY(i+step))");
+				if(i + step > this.bound2)  //Prevent the solid from extending beyond the second bound if it can't be divided by the quality
+				{
+					step = this.bound2 - i;
+				}
+
+				const geometry = new THREE.CylinderGeometry(eval(leftRadius), eval(rightRadius), step, 100);
+				geometry.rotateZ(Math.PI / 2).translate(i + step / 2, this.axisOfRotation, 0);
+				const plane = new THREE.Mesh(geometry, new THREE.MeshPhongMaterial({color: 0xFFFF00/*, transparent: true, opacity: 0.5*/}));
+				geometry.dispose();
+				this.group.add(plane);
+			}
+		}
+	}
+
+	static clear()
+	{
+		for(let i = 0; i < scene.children.length; i++)
+		{
+			if(scene.children[i] !== undefined)
+			{
+				if(scene.children[i].name === "graph" || scene.children[i].name === "solid")
+				{
+					scene.remove(scene.children[i]);
+					i--;
+				}
+			}
+		}
+		Graph.render();
+	}
+
+	static animate()
+	{
+		window.requestAnimationFrame(Graph.animate);
+		controls.update();
+	}
+
+	static render()
+	{
+		renderer.render(scene, camera);
+	}
+
+	static addLights()
+	{
+		const pointLight = new THREE.PointLight(0xFFFF00, 1, 5000);
+		pointLight.position.set(0, 100, 90);
+		scene.add(pointLight);
+		scene.add(new THREE.HemisphereLight(0x3284FF, 0xFFC87F, 0.6));
+	}
+
+	static addAxis()
+	{
+		const lines = new THREE.Geometry();
+		const axes = new THREE.Geometry();
+		for(let i = -size; i <= size; i++)
+		{
+			if(i)
+			{
+				lines.vertices.push(new THREE.Vector3(-size, i, 0),
+				                    new THREE.Vector3(size, i, 0),
+				                    new THREE.Vector3(i, -size, 0),
+				                    new THREE.Vector3(i, size, 0));
 			}
 			else
 			{
-				sweetAlert("Oh noes!", "Axis of rotation cannot be between the functions", "warning");
-				clearGraph();
-				return;
+				axes.vertices.push(new THREE.Vector3(-size, i, 0),
+				                   new THREE.Vector3(size, i, 0),
+				                   new THREE.Vector3(i, -size, 0),
+				                   new THREE.Vector3(i, size, 0));
 			}
 		}
-		else if(boundY1 === boundY2)
-		{
-			//Not complete yet (this is just for cylinders)
-			console.log("\t\tBoundY1 is equal to boundY2 and bound1 does not equal bound2");
-			if(this.axisOfRotation > boundY1)
-			{
-				console.log("\t\t\tAxis of rotation is greater than boundY1");
-				this.addBSP("Math.abs(this.axisOfRotation-this.getY(i))", "Math.abs(this.axisOfRotation-this.getY(i+step))", "Math.abs(this.axisOfRotation)", "Math.abs(this.axisOfRotation)");
-			}
-			else if(this.axisOfRotation < boundY1)
-			{
-				console.log("\t\t\tAxis of rotation is less than boundY1");
-				this.addBSP("Math.abs(this.axisOfRotation)", "Math.abs(this.axisOfRotation)", "Math.abs(this.axisOfRotation)+this.getY(i)", "Math.abs(this.axisOfRotation)+this.getY(i+step)");
-			}
-			else if(this.axisOfRotation === boundY1)
-			{
-				console.log("\t\t\tAxis of rotation is equal to boundY1");
-				this.addSolidWithoutHoles("Math.abs(this.getY(i))", "Math.abs(this.getY(i+step))");
-			}
-		}
+
+		scene.add(new THREE.LineSegments(lines, new THREE.LineBasicMaterial({color: "green"})),
+		          new THREE.LineSegments(axes, new THREE.LineBasicMaterial({color: "red"})));
 	}
-	scene.add(this.group);
-	render();
-};
-
-Graph.prototype.addBSP = function(smallGeoR1, smallGeoR2, bigGeoR1, bigGeoR2)
-{
-	let step = this.quality;
-	for(let i = this.bound1; i < this.bound2; i += step)
-	{
-		if(this.getY(i) <= size)
-		{
-			if(!eval(smallGeoR1) || !eval(smallGeoR2))  //Hacky bugfix woo
-			{
-				smallGeoR1 += "+0.01";
-				smallGeoR2 += "+0.01";
-			}
-
-			if(i + step > this.bound2)  //Prevent the solid from extending beyond the second bound if it can't be divided by the quality
-			{
-				step = this.bound2 - i;
-			}
-
-			const smallCylinderGeom = new THREE.CylinderGeometry(eval(smallGeoR1), eval(smallGeoR2), step, 50);
-			smallCylinderGeom.rotateZ(Math.PI / 2).translate(i + step / 2, this.axisOfRotation, 0);
-			const largeCylinderGeom = new THREE.CylinderGeometry(eval(bigGeoR1), eval(bigGeoR2), step, 360);
-			largeCylinderGeom.rotateZ(Math.PI / 2).translate(i + step / 2, this.axisOfRotation, 0);
-			const smallCylinderBSP = new ThreeBSP(smallCylinderGeom);
-			const largeCylinderBSP = new ThreeBSP(largeCylinderGeom);
-			smallCylinderGeom.dispose();
-			largeCylinderGeom.dispose();
-			const intersectionBSP = largeCylinderBSP.subtract(smallCylinderBSP);
-			const hollowCylinder = intersectionBSP.toMesh(new THREE.MeshPhongMaterial({color: 0xFFFF00/*, transparent: true, opacity: 0.5*/}));
-			this.group.add(hollowCylinder);
-		}
-	}
-};
-
-Graph.prototype.addSolidWithoutHoles = function(leftRadius, rightRadius)
-{
-	let step = this.quality;
-	for(let i = this.bound1; i < this.bound2; i += step)
-	{
-		if(this.getY(i) <= size)
-		{
-			if(i + step > this.bound2)  //Prevent the solid from extending beyond the second bound if it can't be divided by the quality
-			{
-				step = this.bound2 - i;
-			}
-
-			const geometry = new THREE.CylinderGeometry(eval(leftRadius), eval(rightRadius), step, 100);
-			geometry.rotateZ(Math.PI / 2).translate(i + step / 2, this.axisOfRotation, 0);
-			const plane = new THREE.Mesh(geometry, new THREE.MeshPhongMaterial({color: 0xFFFF00/*, transparent: true, opacity: 0.5*/}));
-			geometry.dispose();
-			this.group.add(plane);
-		}
-	}
-};
-
-function clearGraph()
-{
-	for(let i = 0; i < scene.children.length; i++)
-	{
-		if(scene.children[i] !== undefined)
-		{
-			if(scene.children[i].name === "graph" || scene.children[i].name === "solid")
-			{
-				scene.remove(scene.children[i]);
-				i--;
-			}
-		}
-	}
-	render();
 }
 
 function submit() // eslint-disable-line
 {
-	clearGraph();
+	Graph.clear();
 
 	graphArray[0] = undefined;
 	graphArray[1] = undefined;
@@ -362,54 +413,9 @@ function submit() // eslint-disable-line
 	}
 }
 
-function animate()
-{
-	window.requestAnimationFrame(animate);
-	controls.update();
-}
-
-function render()
-{
-	renderer.render(scene, camera);
-}
-
-function addLights()
-{
-	const pointLight = new THREE.PointLight(0xFFFF00, 1, 5000);
-	pointLight.position.set(0, 100, 90);
-	scene.add(pointLight);
-	scene.add(new THREE.HemisphereLight(0x3284FF, 0xFFC87F, 0.6));
-}
-
-function addAxis()
-{
-	const lines = new THREE.Geometry();
-	const axes = new THREE.Geometry();
-	for(let i = -size; i <= size; i++)
-	{
-		if(i)
-		{
-			lines.vertices.push(new THREE.Vector3(-size, i, 0),
-			                    new THREE.Vector3(size, i, 0),
-			                    new THREE.Vector3(i, -size, 0),
-			                    new THREE.Vector3(i, size, 0));
-		}
-		else
-		{
-			axes.vertices.push(new THREE.Vector3(-size, i, 0),
-			                   new THREE.Vector3(size, i, 0),
-			                   new THREE.Vector3(i, -size, 0),
-			                   new THREE.Vector3(i, size, 0));
-		}
-	}
-
-	scene.add(new THREE.LineSegments(lines, new THREE.LineBasicMaterial({color: "green"})),
-	          new THREE.LineSegments(axes, new THREE.LineBasicMaterial({color: "red"})));
-}
-
 function reset()  //eslint-disable-line
 {
-	clearGraph();
+	Graph.clear();
 	controls.reset();
 
 	graphArray[0] = undefined;
@@ -434,5 +440,5 @@ window.onresize = function()
 	camera.aspect = window.innerWidth / (window.innerHeight - totalHeight);
 	camera.updateProjectionMatrix();
 	renderer.setSize(window.innerWidth, window.innerHeight - totalHeight);
-	render();
+	Graph.render();
 };

--- a/js/graph.js
+++ b/js/graph.js
@@ -117,9 +117,9 @@ class Graph
 			}
 		}
 
-		const graph = new THREE.Line(geometry, new THREE.LineBasicMaterial());
-		graph.name = "graph";
-		scene.add(graph);
+		const line = new THREE.Line(geometry, new THREE.LineBasicMaterial());
+		line.name = "line";
+		scene.add(line);
 		Graph.render();
 	}
 
@@ -270,7 +270,7 @@ class Graph
 		{
 			if(scene.children[i] !== undefined)
 			{
-				if(scene.children[i].name === "graph" || scene.children[i].name === "solid")
+				if(scene.children[i].name === "line" || scene.children[i].name === "solid")
 				{
 					scene.remove(scene.children[i]);
 					i--;


### PR DESCRIPTION
According to http://kangax.github.io/compat-table/es6/, Chrome, Firefox, and Edge all have extremely good ES6 support now.  All features within this PR should be supported by the latest versions of each.  Safari on the other hand...well, [Safari is the new Internet Explorer](http://arstechnica.com/information-technology/2015/06/op-ed-safari-is-the-new-internet-explorer/).

| Feature | Chrome 50 | Firefox 45 | Edge 13 | Safari 9 | IE 11 |
| --- | --- | --- | --- | --- | --- |
| `let/const` | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: | :white_check_mark: |
| `class` | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: |
| Spread | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: |
| Destructuring | :white_check_mark: | :white_check_mark: | :x::checkered_flag:* | :white_check_mark: | :x: |
| `=>` | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: | :x: |
| Shorthand object literals | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: |

\* Hidden behind a flag, will be enabled by default in Edge 14
