### PR TITLE
Better error handling

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -80,7 +80,6 @@ rules:
         - 2
         - max: 1
     no-native-reassign: 2
-    no-negated-condition: 1
     no-new-func: 2
     no-new-wrappers: 1
     no-new: 2

--- a/js/graph.js
+++ b/js/graph.js
@@ -580,7 +580,7 @@ function parseEquation(equation, name, equationType, constant = true)
 
 		try
 		{
-			let value = math.eval(math.number(equation.pop().toString()));
+			let value = math.eval(equation.pop().toString());
 			if(math.abs(value) > size)
 			{
 				sweetAlert("Invalid " + name, "The " + name + " must be within " + -size + " to " + size + ", inclusive", "warning");

--- a/js/graph.js
+++ b/js/graph.js
@@ -562,7 +562,14 @@ function parseEquation(equation, name, equationType, constant = true)
 	equation = equation.split(/=\s*/);
 	if(type === EquationType.EQUATION_NONE || type === EquationType.EQUATION_INVALID)
 	{
-		return equation.pop();
+		if(constant)
+		{
+			return;
+		}
+		else
+		{
+			return equation.pop();
+		}
 	}
 
 	if(constant)

--- a/js/graph.js
+++ b/js/graph.js
@@ -565,20 +565,13 @@ function getEquationType(equation, name)
 function parseEquation(equation, name, equationType, constant = true)
 {
 	let type = getEquationType(equation, name);
+	if(type === EquationType.EQUATION_UNKNOWN || type === EquationType.EQUATION_INVALID)
+	{
+		return;
+	}
 
 	equation = equation.split(/=\s*/);
-	if(equation.length > 2)
-	{
-		sweetAlert("Malformed equation", "The " + name + " cannot have more than one equals sign", "error");
-		return;
-	}
-	else if(type === EquationType.EQUATION_INVALID)
-	{
-		sweetAlert("Invalid equation type", "The " + name + " should be a function of x or y", "error");
-		return;
-	}
-
-	if(type !== EquationType.EQUATION_UNKNOWN && constant)
+	if(constant)
 	{
 		if(type !== equationType && name.includes("rotation"))
 		{
@@ -590,10 +583,7 @@ function parseEquation(equation, name, equationType, constant = true)
 			sweetAlert("Incorrect equation type", "The " + name + " should be a function of " + (type === EquationType.EQUATION_X ? "y" : "x"), "error");
 			return;
 		}
-	}
 
-	if(constant)
-	{
 		try
 		{
 			let value = math.eval(math.number(equation.pop().toString()));

--- a/js/graph.js
+++ b/js/graph.js
@@ -4,7 +4,7 @@ let bound1, bound2, rotationAxis;
 const size = 28;
 
 const EquationType = {
-	EQUATION_UNKNOWN: 0,
+	EQUATION_NONE: 0,
 	EQUATION_X: 1,
 	EQUATION_Y: 2,
 	EQUATION_INVALID: 3
@@ -460,13 +460,13 @@ function submit() // eslint-disable-line
 		return;
 	}
 
-	if(type1 === EquationType.EQUATION_UNKNOWN && type2 === EquationType.EQUATION_UNKNOWN)
+	if(type1 === EquationType.EQUATION_NONE && type2 === EquationType.EQUATION_NONE)
 	{
 		return;
 	}
 
-	let type = type1 !== EquationType.EQUATION_UNKNOWN ? type1 : type2;
-	if(type1 !== type2 && type1 !== EquationType.EQUATION_UNKNOWN && type2 !== EquationType.EQUATION_UNKNOWN)
+	let type = type1 !== EquationType.EQUATION_NONE ? type1 : type2;
+	if(type1 !== type2 && type1 !== EquationType.EQUATION_NONE && type2 !== EquationType.EQUATION_NONE)
 	{
 		sweetAlert("Invalid equation type", "The second function should be a function of " + (type === EquationType.EQUATION_X ? "x" : "y"), "error");
 		return;
@@ -552,7 +552,7 @@ function getEquationType(equation, name)
 		sweetAlert("Invalid equation type", "The " + name + " should be a function of x or y", "error");
 		return EquationType.EQUATION_INVALID;
 	}
-	return EquationType.EQUATION_UNKNOWN;
+	return EquationType.EQUATION_NONE;
 }
 
 function parseEquation(equation, name, equationType, constant = true)
@@ -560,7 +560,7 @@ function parseEquation(equation, name, equationType, constant = true)
 	let type = getEquationType(equation, name);
 
 	equation = equation.split(/=\s*/);
-	if(type === EquationType.EQUATION_UNKNOWN || type === EquationType.EQUATION_INVALID)
+	if(type === EquationType.EQUATION_NONE || type === EquationType.EQUATION_INVALID)
 	{
 		return equation.pop();
 	}

--- a/js/graph.js
+++ b/js/graph.js
@@ -67,7 +67,11 @@ class Equation
 
 	getIntersections(otherEquation)
 	{
-		if(otherEquation.points.every((element) => element === undefined))
+		if(this.points.every((element) => element === undefined))
+		{
+			this.points.fill(rotationAxis);
+		}
+		else if(otherEquation.points.every((element) => element === undefined))
 		{
 			otherEquation.points.fill(rotationAxis);
 		}
@@ -567,7 +571,7 @@ function parseEquation(equation, name, equationType, constant = true)
 	let type = getEquationType(equation, name);
 	if(type === EquationType.EQUATION_UNKNOWN || type === EquationType.EQUATION_INVALID)
 	{
-		return;
+		return "";
 	}
 
 	equation = equation.split(/=\s*/);

--- a/js/graph.js
+++ b/js/graph.js
@@ -120,18 +120,7 @@ class Graph
 		this.equation1 = equation1;
 		this.equation2 = equation2;
 		this.quality = quality;
-
-		this.type = EquationType.EQUATION_UNKNOWN;
-		if(this.equation1.getType() !== this.equation2.getType()
-		&& this.equation1.getType() !== EquationType.EQUATION_UNKNOWN
-		&& this.equation2.getType() !== EquationType.EQUATION_UNKNOWN)
-		{
-			sweetAlert("Conflicting rotations", "Both equations must be rotated around the same axis", "warning");
-		}
-		else
-		{
-			this.type = this.equation1.getType();
-		}
+		this.type = this.equation1.getType() !== EquationType.EQUATION_UNKNOWN ? this.equation1.getType() : this.equation2.getType();
 	}
 
 	draw(equation)
@@ -569,12 +558,13 @@ function getEquationType(equation, name)
 function parseEquation(equation, name, equationType, constant = true)
 {
 	let type = getEquationType(equation, name);
-	if(type === EquationType.EQUATION_UNKNOWN || type === EquationType.EQUATION_INVALID)
-	{
-		return "";
-	}
 
 	equation = equation.split(/=\s*/);
+	if(type === EquationType.EQUATION_UNKNOWN || type === EquationType.EQUATION_INVALID)
+	{
+		return equation.pop();
+	}
+
 	if(constant)
 	{
 		if(type !== equationType && name.includes("rotation"))

--- a/js/graph.js
+++ b/js/graph.js
@@ -567,12 +567,7 @@ function parseEquation(equation, name, equationType, constant = true)
 
 	if(constant)
 	{
-		if(type !== equationType && name.includes("rotation"))
-		{
-			sweetAlert("Incorrect equation type", "The " + name + " should be a function of " + (type === EquationType.EQUATION_X ? "y" : "x"), "error");
-			return;
-		}
-		else if(type === equationType && !name.includes("rotation"))
+		if(type !== equationType && name.includes("rotation") || type === equationType && !name.includes("rotation"))
 		{
 			sweetAlert("Incorrect equation type", "The " + name + " should be a function of " + (type === EquationType.EQUATION_X ? "y" : "x"), "error");
 			return;

--- a/js/graph.js
+++ b/js/graph.js
@@ -114,13 +114,13 @@ class Equation
 
 class Graph
 {
-	constructor(equation1, equation2, quality)
+	constructor(equation1, equation2, quality, type)
 	{
 		this.group = new THREE.Object3D();
 		this.equation1 = equation1;
 		this.equation2 = equation2;
 		this.quality = quality;
-		this.type = this.equation1.getType() !== EquationType.EQUATION_UNKNOWN ? this.equation1.getType() : this.equation2.getType();
+		this.type = type;
 	}
 
 	draw(equation)
@@ -520,7 +520,7 @@ function submit() // eslint-disable-line
 		}
 	}
 
-	let graph = new Graph(equation1, equation2, quality);
+	let graph = new Graph(equation1, equation2, quality, type);
 
 	graph.draw(equation1);
 	graph.draw(equation2);


### PR DESCRIPTION
This is a follow-up to #51, which had some basic (and buggy) form validation but basically assumed you would always be doing the correct thing.

This PR builds on that initial framework to provide much more comprehensive feedback when something is invalid.
- A new equation type, `EquationType.EQUATION_INVALID` has been added for invalid equations like `z = 3`.  `EQUATION_UNKNOWN` is now just used for empty equations and may be renamed to `EQUATION_NONE` or `EQUATION_EMPTY`.
- Equation validation has been moved from the `Equation` constructor to `getEquationType()` and `parseEquation()`.  `getEquationType` is primarily concerned with making sure the equation's type is valid and will return alerts if an invalid equation is detected.  `parseEquation` is tasked with making sure the equation type matches with what is expected and that the equation's value is valid.

Note that otherwise valid equations containing symbols unrecognizable by `math.eval()` still don't produce any warnings.
