### PR TITLE
Actually parse equations

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -34,6 +34,7 @@ rules:
     indent:
         - 2
         - tab
+        - SwitchCase: 1
     key-spacing: 2
     keyword-spacing:
         - 2
@@ -109,7 +110,12 @@ rules:
     quote-props:
         - 2
         - as-needed
-    quotes: 2
+    quotes:
+        - 1
+        - double
+        -
+            allowTemplateLiterals: true
+            avoidEscape: true
     semi: 2
     space-before-function-paren:
         - 2

--- a/js/graph.js
+++ b/js/graph.js
@@ -226,13 +226,13 @@ class Graph
 		}
 
 		//Switch the functions around so that the larger one is always first for consistency
-		if(!larger && this.equation2.equation !== undefined && Number(this.equation2.equation) !== rotationAxis)
+		if(!larger && this.equation2.equation !== undefined && this.equation2.equation.eval() !== rotationAxis)
 		{
 			[this.equation1.equation, this.equation2.equation] = [this.equation2.equation, this.equation1.equation];
 			[this.equation1.points, this.equation2.points] = [this.equation2.points, this.equation1.points];
 		}
 
-		if(this.equation2.equation === undefined || Number(this.equation2.equation) === rotationAxis)  //FIXME: This doesn't catch constants
+		if(this.equation2.equation === undefined || this.equation2.equation.eval() === rotationAxis)
 		{
 			console.log("No second function or second function is equal to the axis of rotation");
 			this.addSolidWithoutHoles("Math.abs(this.equation1.getCoord(i))", "Math.abs(this.equation1.getCoord(i+step))");

--- a/js/graph.js
+++ b/js/graph.js
@@ -521,8 +521,20 @@ function submit() // eslint-disable-line
 		return;
 	}
 
-	const equation1 = new Equation(parseEquation(function1, "first function", type, false), type1);
-	const equation2 = new Equation(parseEquation(function2, "second function", type, false), type2);
+	function1 = parseEquation(function1, "first function", type, false);
+	if(function1 === false)
+	{
+		return;
+	}
+
+	function2 = parseEquation(function2, "second function", type, false);
+	if(function2 === false)
+	{
+		return;
+	}
+
+	const equation1 = new Equation(function1, type1);
+	const equation2 = new Equation(function2, type2);
 
 	// We'll reassign these later to their actual values, but for now we just need to know if they're defined
 	bound1 = document.getElementById("bound1").value.trim().length;
@@ -544,21 +556,21 @@ function submit() // eslint-disable-line
 	{
 		// FIXME: I am NOT proud of this nested if chain AT ALL
 		bound1 = parseEquation(document.getElementById("bound1").value, "first bound", type);
-		if(bound1 === undefined)
+		if(bound1 === false)
 		{
 			drawSolid = false;
 		}
 		else
 		{
 			bound2 = parseEquation(document.getElementById("bound2").value, "second bound", type);
-			if(bound2 === undefined)
+			if(bound2 === false)
 			{
 				drawSolid = false;
 			}
 			else
 			{
 				rotationAxis = parseEquation(document.getElementById("rotation").value, "axis of rotation", type);
-				if(rotationAxis === undefined)
+				if(rotationAxis === false)
 				{
 					drawSolid = false;
 				}
@@ -604,14 +616,25 @@ function getEquationType(equation, name)
 	return EquationType.EQUATION_NONE;
 }
 
+/**
+ * Returns:
+ * `false` if an invalid equation is passed
+ * `undefined` if an empty equation is passed
+ * The constant value if constant = true
+ * The parser for the equation if constant = false
+ */
 function parseEquation(equation, name, equationType, constant = true)
 {
-	let type = getEquationType(equation, name);
+	const type = getEquationType(equation, name);
 
 	equation = equation.split(/=\s*/);
-	if(type === EquationType.EQUATION_NONE || type === EquationType.EQUATION_INVALID)
+	if(type === EquationType.EQUATION_NONE)
 	{
-		return;
+		return undefined;
+	}
+	else if(type === EquationType.EQUATION_INVALID)
+	{
+		return false;
 	}
 
 	if(constant)
@@ -619,28 +642,28 @@ function parseEquation(equation, name, equationType, constant = true)
 		if(type !== equationType && name.includes("rotation") || type === equationType && !name.includes("rotation"))
 		{
 			sweetAlert("Incorrect equation type", "The " + name + " should be a function of " + (type === EquationType.EQUATION_X ? "y" : "x"), "error");
-			return;
+			return false;
 		}
 
 		try
 		{
-			let value = math.eval(equation.pop().toString());
+			const value = math.eval(equation.pop().toString());
 			if(math.abs(value) > size)
 			{
 				sweetAlert("Invalid " + name, "The " + name + " must be within " + -size + " to " + size + ", inclusive", "warning");
-				return;
+				return false;
 			}
 			return value;
 		}
 		catch(error)
 		{
 			sweetAlert("Invalid " + name, "Please enter a valid number for the " + name, "warning");
-			return;
+			return false;
 		}
 	}
 	else
 	{
-		let parser = math.parse(equation.pop());
+		const parser = math.parse(equation.pop());
 		let valid = true;
 		parser.traverse((node) =>
 		{
@@ -677,7 +700,7 @@ function parseEquation(equation, name, equationType, constant = true)
 		}
 		else
 		{
-			return;
+			return false;
 		}
 	}
 }

--- a/js/graph.js
+++ b/js/graph.js
@@ -408,6 +408,7 @@ class Graph
 	static animate()
 	{
 		window.requestAnimationFrame(Graph.animate);
+		Graph.render();
 		controls.update();
 	}
 
@@ -482,7 +483,6 @@ function init()
 	Graph.addAxis();
 	Graph.addLights();
 	Graph.animate();
-	Graph.render();
 }
 
 function submit() // eslint-disable-line

--- a/js/graph.js
+++ b/js/graph.js
@@ -664,7 +664,17 @@ function parseEquation(equation, name, equationType, constant = true)
 	}
 	else
 	{
-		const parser = math.parse(equation.pop());
+		let parser;
+		try
+		{
+			parser = math.parse(equation.pop());
+		}
+		catch(error) // Parsing can fail if unexpected values are passed in, eg '!', '(', '@', '.', etc.
+		{
+			sweetAlert("Invalid " + name, "Please enter a valid equation", "error");
+			return false;
+		}
+
 		let valid = true;
 		parser.traverse((node) =>
 		{

--- a/js/graph.js
+++ b/js/graph.js
@@ -48,7 +48,7 @@ class Equation
 	getPoints()
 	{
 		let points = [];
-		if(this.equation === undefined || this.type !== EquationType.EQUATION_Y && this.type !== EquationType.EQUATION_X)
+		if(this.equation === undefined || this.type !== EquationType.EQUATION_NONE)
 		{
 			for(let x = -size; x <= size + 1; x += 0.01) // Add 1 to the ending size because of the origin
 			{

--- a/js/graph.js
+++ b/js/graph.js
@@ -48,7 +48,7 @@ class Equation
 	getPoints()
 	{
 		let points = [];
-		if(this.equation === undefined || this.type !== EquationType.EQUATION_NONE)
+		if(this.equation === undefined || this.type === EquationType.EQUATION_NONE)
 		{
 			for(let x = -size; x <= size + 1; x += 0.01) // Add 1 to the ending size because of the origin
 			{

--- a/js/graph.js
+++ b/js/graph.js
@@ -408,7 +408,6 @@ class Graph
 	static animate()
 	{
 		window.requestAnimationFrame(Graph.animate);
-		Graph.render();
 		controls.update();
 	}
 
@@ -483,6 +482,7 @@ function init()
 	Graph.addAxis();
 	Graph.addLights();
 	Graph.animate();
+	Graph.render();
 }
 
 function submit() // eslint-disable-line

--- a/js/graph.js
+++ b/js/graph.js
@@ -681,7 +681,9 @@ function parseEquation(equation, name, equationType, constant = true)
 					valid = false;
 					return;
 				case "SymbolNode":
-					if(node.name in math || node.name === "x" && type === EquationType.EQUATION_Y || node.name === "y" && type === EquationType.EQUATION_X)
+					if(node.name in math
+					|| node.name === "x" && type === EquationType.EQUATION_Y
+					|| node.name === "y" && type === EquationType.EQUATION_X)
 					{
 						break;
 					}
@@ -694,14 +696,7 @@ function parseEquation(equation, name, equationType, constant = true)
 			}
 		});
 
-		if(valid)
-		{
-			return parser;
-		}
-		else
-		{
-			return false;
-		}
+		return valid ? parser : false;
 	}
 }
 

--- a/js/graph.js
+++ b/js/graph.js
@@ -680,7 +680,7 @@ function parseEquation(equation, name, equationType, constant = true)
 					valid = false;
 					return;
 				case "SymbolNode":
-					if(node.name in math
+					if(node.name in math && typeof math[node.name] === "number"
 					|| node.name === "x" && type === EquationType.EQUATION_Y
 					|| node.name === "y" && type === EquationType.EQUATION_X)
 					{
@@ -689,6 +689,17 @@ function parseEquation(equation, name, equationType, constant = true)
 					else
 					{
 						sweetAlert("Invalid " + name, "Unknown variable " + node.name, "error");
+						valid = false;
+						return;
+					}
+				case "FunctionNode":
+					if(node.name in math && typeof math[node.name] === "function")
+					{
+						break;
+					}
+					else
+					{
+						sweetAlert("Invalid " + name, "Unknown function " + node.name, "error");
 						valid = false;
 						return;
 					}

--- a/js/graph.js
+++ b/js/graph.js
@@ -673,7 +673,6 @@ function parseEquation(equation, name, equationType, constant = true)
 				case "ArrayNode":
 				case "AssignmentNode":
 				case "BlockNode":
-				case "FunctionAssignmentNode": // TODO: This could actually be useful
 				case "IndexNode":
 				case "ObjectNode":
 				case "RangeNode":
@@ -693,6 +692,10 @@ function parseEquation(equation, name, equationType, constant = true)
 						valid = false;
 						return;
 					}
+				case "FunctionAssignmentNode":
+					sweetAlert("Invalid " + name, "f(x) syntax is currently unsupported.  Check back later!", "warning");
+					valid = false;
+					return;
 			}
 		});
 


### PR DESCRIPTION
Use the very handy `math.parse(equation)` function and the trick I learned from https://github.com/josdejong/mathjs/issues/692#issuecomment-235069756 to traverse each "node" in order to see if the equation is valid.  This fixes cases where users could pass in `y=z` as a function and get no visual feedback that there was an error when attempting to graph it.  It also fixes sneaky people trying to use unsupported features such as `y=x[1]`.
