### PR TITLE
Fix what 'larger' actually means

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,4 +10,5 @@ When making a PR please make sure that the following test cases work as expected
 | `y=x` | `y=x^2` | `x=0` | `x=1` | `y=0` |
 | `y=x^2` | `y=x` | `x=0` | `x=1` | `y=0` |
 | `(undefined)` | `y=-x^2` | `x=-3` | `x=3` | `y=3` |
-| `y=-x^2` | `(undefined)` | `x=-3` | `x=3` | `y=3`|
+| `y=-x^2` | `(undefined)` | `x=-3` | `x=3` | `y=3` |
+| `y=x^2-2x` | `y=x` | `x=0` | `x=3` | `y=4` |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,3 +12,5 @@ When making a PR please make sure that the following test cases work as expected
 | `(undefined)` | `y=-x^2` | `x=-3` | `x=3` | `y=3` |
 | `y=-x^2` | `(undefined)` | `x=-3` | `x=3` | `y=3` |
 | `y=x^2-2x` | `y=x` | `x=0` | `x=3` | `y=4` |
+| `x=y` | `x=sqrt(y)` | `y=1` | `y=5` | `x=0` |
+| `x=y` | `x=sqrt(y)` | `y=1` | `y=5` | `x=10` |

--- a/js/graph.js
+++ b/js/graph.js
@@ -102,14 +102,13 @@ class Equation
 		}
 
 		let larger;
-
 		for(let x = math.round(100 * (size + bound1)); x < 100 * (size + bound2); x++)
 		{
 			if(this.points[x] > otherEquation.points[x])
 			{
 				if(larger === false)
 				{
-					return [x / 100 - size, true]; // Convert back into actual x coordinates
+					return x / 100 - size; // Convert back into actual x coordinates
 				}
 				larger = true;
 			}
@@ -117,16 +116,41 @@ class Equation
 			{
 				if(larger === true)
 				{
-					return [x / 100 - size, false]; // Convert back into actual x coordinates
+					return x / 100 - size; // Convert back into actual x coordinates
 				}
 				larger = false;
 			}
 			else // Obviously intersecting when the two functions are equal
 			{
-				return [x / 100 - size, undefined]; // Convert back into actual x coordinates
+				return x / 100 - size; // Convert back into actual x coordinates
 			}
 		}
-		return [undefined, larger];
+		return undefined;
+	}
+
+	getLargerEquation(otherEquation)
+	{
+		if(this.equation === undefined)
+		{
+			return otherEquation;
+		}
+		else if(otherEquation.equation === undefined)
+		{
+			return this;
+		}
+
+		for(let x = math.round(100 * (size + bound1)); x < 100 * (size + bound2); x++)
+		{
+			if(math.abs(this.points[x] - rotationAxis) > math.abs(otherEquation.points[x] - rotationAxis))
+			{
+				return this;
+			}
+			else if(math.abs(this.points[x] - rotationAxis) < math.abs(otherEquation.points[x] - rotationAxis))
+			{
+				return otherEquation;
+			}
+		}
+		return this; // Hopefully we never reach this point
 	}
 
 	getType()
@@ -225,7 +249,7 @@ class Graph
 		this.group.name = "solid";
 
 		let boundY1 = this.equation1.getCoord(bound1);
-		let boundY2 = this.equation2.getCoord(bound2);
+		let boundY2 = this.equation1.getCoord(bound2);
 
 		if(bound1 === bound2)
 		{
@@ -240,7 +264,7 @@ class Graph
 			[boundY1, boundY2] = [boundY2, boundY1];
 		}
 
-		const [intersection, larger] = this.equation1.getIntersectionWith(this.equation2);
+		const intersection = this.equation1.getIntersectionWith(this.equation2);
 
 		if(intersection !== undefined)
 		{
@@ -249,8 +273,7 @@ class Graph
 			return;
 		}
 
-		// We assume in addBSP() that equation1 - equation2 will equal something non-negative
-		if(!larger)
+		if(this.equation1.getLargerEquation(this.equation2) === this.equation2) // We assume in addBSP() that equation1 is the 'larger' equation
 		{
 			[this.equation1, this.equation2] = [this.equation2, this.equation1];
 		}

--- a/js/graph.js
+++ b/js/graph.js
@@ -128,31 +128,6 @@ class Equation
 		return undefined;
 	}
 
-	getLargerEquation(otherEquation)
-	{
-		if(this.equation === undefined)
-		{
-			return otherEquation;
-		}
-		else if(otherEquation.equation === undefined)
-		{
-			return this;
-		}
-
-		for(let x = math.round(100 * (size + bound1)); x < 100 * (size + bound2); x++)
-		{
-			if(math.abs(this.points[x] - rotationAxis) > math.abs(otherEquation.points[x] - rotationAxis))
-			{
-				return this;
-			}
-			else if(math.abs(this.points[x] - rotationAxis) < math.abs(otherEquation.points[x] - rotationAxis))
-			{
-				return otherEquation;
-			}
-		}
-		return this; // Hopefully we never reach this point
-	}
-
 	getType()
 	{
 		return this.type;
@@ -273,7 +248,7 @@ class Graph
 			return;
 		}
 
-		if(this.equation1.getLargerEquation(this.equation2) === this.equation2) // We assume in addBSP() that equation1 is the 'larger' equation
+		if(this.getFartherEquation() === this.equation2) // We assume in addBSP() that equation1 is farther away from the rotation axis than equation2
 		{
 			[this.equation1, this.equation2] = [this.equation2, this.equation1];
 		}
@@ -410,6 +385,31 @@ class Graph
 				this.group.add(plane);
 			}
 		}
+	}
+
+	getFartherEquation() // Returns the equation that is farther away from the rotation axis
+	{
+		if(this.equation1.equation === undefined)
+		{
+			return this.equation2;
+		}
+		else if(this.equation2.equation === undefined)
+		{
+			return this.equation1;
+		}
+
+		for(let x = math.round(100 * (size + bound1)); x < 100 * (size + bound2); x++)
+		{
+			if(math.abs(this.equation1.points[x] - rotationAxis) > math.abs(this.equation2.points[x] - rotationAxis))
+			{
+				return this.equation1;
+			}
+			else if(math.abs(this.equation1.points[x] - rotationAxis) < math.abs(this.equation2.points[x] - rotationAxis))
+			{
+				return this.equation2;
+			}
+		}
+		return this.equation1; // Hopefully we never reach this point
 	}
 
 	static clear()


### PR DESCRIPTION
Fixes #63

Previously we were interpreting 'larger' as "which equation has a higher y-value?".  This is incorrect if we're rotating _above_ the two equations.
The real interpretation should be "which equation is farther away from the axis of rotation?", and is what `addBSP()` expects.
This PR fixes that and also untangles the ugly double-return that `getIntersectionWith()` was doing.
In addition, a possible bug with `boundY2` was fixed (though I'm still not sure I know what that's really there for).

Test cases all pass :sparkles:.
